### PR TITLE
Skip regular expression matcher deprecation warning

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,6 @@ Output
 
 TODO
 =====
- - NOTE: Dependency.new w/ a regexp is deprecated. Dependency.new called from gem-dependent/lib/rubygems/dependent.rb:70
  - include nested dependencies (a > b > c --> a = [b,c])
  - add tests for cli interface
  - add `--type development` support

--- a/lib/rubygems/dependent.rb
+++ b/lib/rubygems/dependent.rb
@@ -66,7 +66,7 @@ module Gem
       all = true
       matching_platform = false
       prerelease = false
-      matcher = Gem::Dependency.new(//, Gem::Requirement.default) # any name, any version
+      matcher = without_deprecation_warning { Gem::Dependency.new(//, Gem::Requirement.default) } # any name, any version
       specs_and_sources = fetcher.find_matching matcher, all, matching_platform, prerelease
 
       if options[:all_versions]
@@ -74,6 +74,14 @@ module Gem
       else
         uniq_by(specs_and_sources){|a| a.first.first }
       end
+    end
+
+    def self.without_deprecation_warning(&block)
+      previous = Gem::Deprecate.skip
+      Gem::Deprecate.skip = true
+      yield
+    ensure
+      Gem::Deprecate.skip = previous
     end
 
     # get unique elements from an array (last found is used)


### PR DESCRIPTION
Matching using a regular expression is deprecated with no replacement functionality. Therefore I'd say it's reasonable to silence that message.

https://github.com/rubygems/rubygems/blob/master/lib/rubygems/dependency.rb#L41
